### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/scs-azure-org/837d4669-bf4a-403c-aa80-fc98bae6d21e/02ef9a7d-adad-4922-9b23-0cc5c01046a0/_apis/work/boardbadge/7e8f5e67-fe9c-4652-8ca2-6d5bf6632e89)](https://dev.azure.com/scs-azure-org/837d4669-bf4a-403c-aa80-fc98bae6d21e/_boards/board/t/02ef9a7d-adad-4922-9b23-0cc5c01046a0/Microsoft.RequirementCategory)
 # Microsoft Azure Data Factory Samples #
 
 This folder contains samples for the Azure Data Factory


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#69](https://dev.azure.com/scs-azure-org/837d4669-bf4a-403c-aa80-fc98bae6d21e/_workitems/edit/69). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.